### PR TITLE
Make the handler actually use the formatter.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 google-api-python-client
+oauth2client

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ with open('README.rst', 'r') as fp:
     pubsub_logging_long_description = fp.read()
 
 REQUIREMENTS = [
-    'google-api-python-client >= 1.4.0'
+    'google-api-python-client >= 1.4.0',
+    'oauth2client >= 4.1.3',
 ]
 
 setup(


### PR DESCRIPTION
to my understanding, setting a formatter to a handler had no influence on the logged message.

the solution I propose is inspired by what is done in standard library: https://github.com/python/cpython/blob/master/Lib/logging/__init__.py#L1093